### PR TITLE
Another approach, a little bit more automatic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Sublime Text 2
+*.sublime-project
+*.sublime-workspace

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,37 @@
+[
+    {
+        "caption": "Licence Snippet: Apache",
+        "command": "insert_licence",
+        "args": {"name": "Apache"}
+    },
+    {
+        "caption": "Licence Snippet: GPLv2",
+        "command": "insert_licence",
+        "args": {"name": "GPL2"}
+    },
+    {
+        "caption": "Licence Snippet: GPLv3",
+        "command": "insert_licence",
+        "args": {"name": "GPL3"}
+    },
+    {
+        "caption": "Licence Snippet: BSDv2",
+        "command": "insert_licence",
+        "args": {"name": "BSD2"}
+    },
+    {
+        "caption": "Licence Snippet: BSDv3",
+        "command": "insert_licence",
+        "args": {"name": "BSD3"}
+    },
+    {
+        "caption": "Licence Snippet: LGPLv2",
+        "command": "insert_licence",
+        "args": {"name": "LGPL2"}
+    },
+    {
+        "caption": "Licence Snippet: MIT",
+        "command": "insert_licence",
+        "args": {"name": "MIT"}
+    }
+]

--- a/Licence Snippets.py
+++ b/Licence Snippets.py
@@ -1,0 +1,80 @@
+import os
+import os.path
+import re
+
+from collections import Callable
+from datetime import date
+from getpass import getuser
+
+from sublime_plugin import TextCommand
+
+
+# This must be computed on import because of the way ST2 load plugins (__file__
+# ends up being relative to plugin's directory and cwd may change later).
+SNIPPETS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                            'snippets'))
+
+# Mapping of additional snippet variable names to their values. If the value is
+# callable, it is called on snippet insertion to compute actual value.
+SNIPPET_VARS = {
+    'YEAR': date.today().year,  # TM_YEAR doesn't seem to be supported.
+    'USER': getuser()  # TM_FULLNAME doesn't seem to be supported.
+}
+
+
+def inc_placeholder(match):
+    ''' Return matched text with number captured by group "num" increased. '''
+    s = match.string
+    a, b = match.span()
+    i, j = match.span('num')
+    return s[a:i] + str(int(s[i:j]) + 1) + s[j:b]
+
+
+def load_snippet(file_name):
+    # Load the file assuming UTF-8.
+    with open(os.path.join(SNIPPETS_DIR, file_name), 'rU') as f:
+        text = f.read().decode('utf-8')
+
+    # Wrap everything in one big tabstop and renumber old tabstops. This is
+    # done for technical reasons to support automatic commenting/warpping
+    # inserted text.
+    text = re.sub(r'(?:\\\\)*\$(\{)?(?P<num>\d+)(?(1)[:/}]|)', inc_placeholder,
+                  text)
+    text = u'${{1:{0}}}'.format(text)
+
+    return text
+
+
+class InsertLicenceCommand(TextCommand):
+    def run(self, edit, name):
+        view = self.view
+        settings = view.settings()
+
+        comment_style = settings.get('licence_comment_style', 'line')
+        if comment_style not in ('none', 'line', 'block'):
+            raise ValueError('Invalid value for licence_comment_style setting')
+
+        wrap_lines = settings.get('licence_wrap_lines', False)
+        if wrap_lines not in (True, False):
+            raise ValueError('Invalid value for licence_wrap_lines setting')
+
+        args = {'contents': load_snippet(name)}
+        for key, value in SNIPPET_VARS.iteritems():
+            if isinstance(value, Callable):
+                value = value()
+            args[key] = unicode(value)  # Allow non-text values.
+        view.run_command('insert_snippet', args)
+
+        # Since load_snippet wraps everything in one big tabstop, the whole
+        # inserted text is now selected.
+        if comment_style != 'none':
+            view.run_command('toggle_comment',
+                             {'block': comment_style == 'block'})
+        if wrap_lines:
+            view.run_command('wrap_lines')
+
+        # Proceed to original first tabstop.
+        view.run_command('next_field')
+
+    def is_enabled(self):
+        return len(self.view.sel()) == 1

--- a/snippets/Apache
+++ b/snippets/Apache
@@ -1,6 +1,4 @@
-<snippet>
-    <content><![CDATA[
-Copyright ${1:[yyyy]} ${2:[name of copyright owner]}
+Copyright ${1:$YEAR} ${2:$USER}
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +11,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-]]></content>
-    <tabTrigger>_apache</tabTrigger>
-    <description>Apache 2.0 licence header</description>
-</snippet>

--- a/snippets/BSD2
+++ b/snippets/BSD2
@@ -1,6 +1,4 @@
-<snippet>
-    <content><![CDATA[
-Copyright (c) ${1:<YEAR>}, ${2:<OWNER>}
+Copyright (c) ${1:$YEAR}, ${2:$USER}
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -13,10 +11,6 @@ modification, are permitted provided that the following conditions are met:
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
 
- - Neither the name of ${3:the <ORGANIZATION>} nor the names of its contributors
-   may be used to endorse or promote products derived from this software without
-   specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,8 +21,3 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-]]></content>
-    <tabTrigger>_bsd3</tabTrigger>
-    <description>BSD 3-clause licence</description>
-</snippet>

--- a/snippets/BSD3
+++ b/snippets/BSD3
@@ -1,6 +1,4 @@
-<snippet>
-    <content><![CDATA[
-Copyright (c) ${1:<YEAR>}, ${2:<OWNER>}
+Copyright (c) ${1:$YEAR}, ${2:$USER}
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -13,6 +11,10 @@ modification, are permitted provided that the following conditions are met:
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
 
+ - Neither the name of ${3:${ORGANIZATION:ORGANIZATION}} nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -23,8 +25,3 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-]]></content>
-    <tabTrigger>_bsd</tabTrigger>
-    <description>BSD 2-clause licence</description>
-</snippet>

--- a/snippets/GPL2
+++ b/snippets/GPL2
@@ -1,6 +1,4 @@
-<snippet>
-    <content><![CDATA[
-Copyright (C) ${1:<year>} ${2:<name of author>}
+Copyright (C) ${1:$YEAR} ${2:$USER}
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software
@@ -14,8 +12,3 @@ FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
-
-]]></content>
-    <tabTrigger>_gpl2</tabTrigger>
-    <description>GPL v2 licence header</description>
-</snippet>

--- a/snippets/GPL3
+++ b/snippets/GPL3
@@ -1,6 +1,4 @@
-<snippet>
-    <content><![CDATA[
-Copyright (C) ${1:<year>}  ${2:<name of author>}
+Copyright (C) ${1:$YEAR}  ${2:$USER}
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -14,8 +12,3 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-]]></content>
-    <tabTrigger>_gpl3</tabTrigger>
-    <description>GPL v3 licence header</description>
-</snippet>

--- a/snippets/LGPL2
+++ b/snippets/LGPL2
@@ -1,6 +1,4 @@
-<snippet>
-    <content><![CDATA[
-Copyright (C) ${1:<year>} ${2:<name of author>}
+Copyright (C) ${1:$YEAR} ${2:$USER}
 
 This library is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free
@@ -15,8 +13,3 @@ details.
 You should have received a copy of the GNU Lesser General Public License along
 with this library; if not, write to the Free Software Foundation, Inc., 59
 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-
-]]></content>
-    <tabTrigger>_lgpl</tabTrigger>
-    <description>LGPL v2.1 licence header</description>
-</snippet>

--- a/snippets/MIT
+++ b/snippets/MIT
@@ -1,6 +1,4 @@
-<snippet>
-    <content><![CDATA[
-Copyright (c) ${1:<year>} ${2:<copyright holders>}
+Copyright (c) ${1:$YEAR} ${2:$USER}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,8 +17,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-]]></content>
-    <tabTrigger>_mit</tabTrigger>
-    <description>MIT licence</description>
-</snippet>


### PR DESCRIPTION
This is probably an overkill, but still I wanted to write it for fun.

Inserted licenses have default var computed by python code (eg. year), and can be automatically wrapped in a comment (licence_comment_style setting can be one of "none", "line" and "block").

Feel free to merge if you find this approach more useful.
