### PR TITLE
[Fixed] Copyright symbol

### DIFF
--- a/snippets/AGPL-3.0.full
+++ b/snippets/AGPL-3.0.full
@@ -1,7 +1,7 @@
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright © 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -630,7 +630,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    Copyright © <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published

--- a/snippets/AGPL-3.0.header
+++ b/snippets/AGPL-3.0.header
@@ -1,4 +1,4 @@
-Copyright (C) ${1:$YEAR} ${2:$USER}
+Copyright © ${1:$YEAR} ${2:$USER}
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/snippets/Apache-2.0.full
+++ b/snippets/Apache-2.0.full
@@ -97,7 +97,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
   (b) You must cause any modified files to carry prominent notices
       stating that You changed the files; and
 
-  (c) You must retain, in the Source form of any Derivative Works
+  © You must retain, in the Source form of any Derivative Works
       that You distribute, all copyright, patent, trademark, and
       attribution notices from the Source form of the Work,
       excluding those notices that do not pertain to any part of

--- a/snippets/Apache-2.0.full
+++ b/snippets/Apache-2.0.full
@@ -97,7 +97,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
   (b) You must cause any modified files to carry prominent notices
       stating that You changed the files; and
 
-  © You must retain, in the Source form of any Derivative Works
+  (c) You must retain, in the Source form of any Derivative Works
       that You distribute, all copyright, patent, trademark, and
       attribution notices from the Source form of the Work,
       excluding those notices that do not pertain to any part of

--- a/snippets/Artistic-2.0.full
+++ b/snippets/Artistic-2.0.full
@@ -105,7 +105,7 @@ you do at least ONE of the following:
     addition, the Modified Version must bear a name that is different
     from the name of the Standard Version.
 
-    ©  allow anyone who receives a copy of the Modified Version to
+    (c)  allow anyone who receives a copy of the Modified Version to
     make the Source form of the Modified Version available to others
     under
 

--- a/snippets/Artistic-2.0.full
+++ b/snippets/Artistic-2.0.full
@@ -1,6 +1,6 @@
                         The Artistic License 2.0
 
-             Copyright (c) 2000-2006, The Perl Foundation.
+             Copyright © 2000-2006, The Perl Foundation.
 
      Everyone is permitted to copy and distribute verbatim copies
       of this license document, but changing it is not allowed.
@@ -105,7 +105,7 @@ you do at least ONE of the following:
     addition, the Modified Version must bear a name that is different
     from the name of the Standard Version.
 
-    (c)  allow anyone who receives a copy of the Modified Version to
+    ©  allow anyone who receives a copy of the Modified Version to
     make the Source form of the Modified Version available to others
     under
 

--- a/snippets/BSD-2-Clause.full
+++ b/snippets/BSD-2-Clause.full
@@ -1,4 +1,4 @@
-Copyright (c) ${1:$YEAR}, ${2:$USER} All rights reserved.
+Copyright © ${1:$YEAR}, ${2:$USER} All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/snippets/BSD-3-Clause.full
+++ b/snippets/BSD-3-Clause.full
@@ -1,4 +1,4 @@
-Copyright (c) ${1:$YEAR}, ${2:$USER} All rights reserved.
+Copyright © ${1:$YEAR}, ${2:$USER} All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/snippets/EPL-1.0.header
+++ b/snippets/EPL-1.0.header
@@ -1,4 +1,4 @@
-Copyright (c) ${1:$YEAR} ${2:$USER}
+Copyright © ${1:$YEAR} ${2:$USER}
 
 All rights reserved. This program and the accompanying materials are made
 available under the terms of the Eclipse Public License v1.0 which

--- a/snippets/GPL-2.0.full
+++ b/snippets/GPL-2.0.full
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ Copyright © 1989, 1991 Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
@@ -291,7 +291,7 @@ convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    Copyright © <year>  <name of author>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -312,7 +312,7 @@ Also add information on how to contact you by electronic and paper mail.
 If the program is interactive, make it output a short notice like this
 when it starts in an interactive mode:
 
-    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision version 69, Copyright © year name of author
     Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/snippets/GPL-2.0.header
+++ b/snippets/GPL-2.0.header
@@ -1,4 +1,4 @@
-Copyright (C) ${1:$YEAR}  ${2:$USER}
+Copyright © ${1:$YEAR}  ${2:$USER}
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the Free

--- a/snippets/GPL-3.0.full
+++ b/snippets/GPL-3.0.full
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright © 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -632,7 +632,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    Copyright © <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+    <program>  Copyright © <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/snippets/GPL-3.0.header
+++ b/snippets/GPL-3.0.header
@@ -1,4 +1,4 @@
-Copyright (C) ${1:$YEAR}  ${2:$USER}
+Copyright © ${1:$YEAR}  ${2:$USER}
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the Free

--- a/snippets/ISC.full
+++ b/snippets/ISC.full
@@ -1,4 +1,4 @@
-Copyright (c) ${1:$YEAR} ${2:$USER}
+Copyright © ${1:$YEAR} ${2:$USER}
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/snippets/LGPL-2.1.full
+++ b/snippets/LGPL-2.1.full
@@ -1,7 +1,7 @@
                   GNU LESSER GENERAL PUBLIC LICENSE
                        Version 2.1, February 1999
 
- Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ Copyright © 1991, 1999 Free Software Foundation, Inc.
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
@@ -471,7 +471,7 @@ convey the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the library's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    Copyright © <year>  <name of author>
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public

--- a/snippets/LGPL-2.1.header
+++ b/snippets/LGPL-2.1.header
@@ -1,4 +1,4 @@
-Copyright (C) ${1:$YEAR}  ${2:$USER}
+Copyright © ${1:$YEAR}  ${2:$USER}
 
 This library is free software; you can redistribute it and/or modify it
 under the terms of the GNU Lesser General Public License as published by

--- a/snippets/LGPL-3.0.full
+++ b/snippets/LGPL-3.0.full
@@ -1,7 +1,7 @@
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright © 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/snippets/LGPL-3.0.header
+++ b/snippets/LGPL-3.0.header
@@ -1,4 +1,4 @@
-Copyright (C) ${1:$YEAR}  ${2:$USER}
+Copyright © ${1:$YEAR}  ${2:$USER}
 
 This library is free software; you can redistribute it and/or modify it
 under the terms of the GNU Lesser General Public License as published by

--- a/snippets/MIT.full
+++ b/snippets/MIT.full
@@ -1,4 +1,4 @@
-Copyright (c) ${1:$YEAR} ${2:$USER}
+Copyright © ${1:$YEAR} ${2:$USER}
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
I replace `(c)` to copyright symbol `©`. See article [**“Trademark and copyright symbols”**](http://practicaltypography.com/trademark-and-copyright-symbols.html).

Thanks.