### PR TITLE
Add feature for selecting custom author name or system username

### DIFF
--- a/Licence Snippets.py
+++ b/Licence Snippets.py
@@ -42,12 +42,20 @@ def get_snippet_dir():
     return SNIPPETS_DIR
 
 
-def get_snippet_vars():
+def get_snippet_vars(settings):
     # Mapping of additional snippet variable names to their values. If the value is
     # callable, it is called on snippet insertion to compute actual value.
+    use_name = settings.get('use_name', 'system')
+    if use_name == 'system':
+        author_name = getuser() # TM_FULLNAME doesn't seem to be supported.
+    elif use_name == 'author':
+        author_name = settings.get('author_name', 'add "author_name": "your_name" in preferences->settings(user)')
+    else:
+        raise ValueError('Invalid value for use_name setting')
+
     SNIPPET_VARS = {
         'YEAR': date.today().year,  # TM_YEAR doesn't seem to be supported.
-        'USER': getuser()  # TM_FULLNAME doesn't seem to be supported.
+        'USER': author_name
     }
     return SNIPPET_VARS
 
@@ -90,7 +98,7 @@ class InsertLicenceCommand(TextCommand):
             raise ValueError('Invalid value for licence_wrap_lines setting')
 
         args = {'contents': load_snippet(name)}
-        for key, value in get_snippet_vars().items():
+        for key, value in get_snippet_vars(settings).items():
             if isinstance(value, Callable):
                 value = value()
             args[key] = str(value) if ST3 else unicode(value)

--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ for the setting you want to change.
 
 - *licence_comment_style* = *none*, *line*, or *block* (default: *line*)
 - *licence_wrap_lines* = *True* or *False* (default: *False*)
+
+You can switch between system user name and your custom author name.
+- *use_name* = *system* or *author* (default: *system*)
+- *author_name* = *your_name_here* (default: *add "author_name": "your_name" in preferences->settings(user)*)


### PR DESCRIPTION
Implements request for new feature #11. 
Now you can add lines a few lines in preferences->settings(user) and automatically add custom author name in licenses.